### PR TITLE
add ability to define paths for searching for coverage reports

### DIFF
--- a/general.go
+++ b/general.go
@@ -60,6 +60,10 @@ func (p *Plugin) command() *exec.Cmd {
 		args = append(args, fmt.Sprintf("-f '%s'", file))
 	}
 
+	for _, path := range p.Config.Paths {
+		args = append(args, fmt.Sprintf("-s '%s'", path))
+	}
+
 	fmt.Println("$", strings.Join(args, " "))
 
 	return exec.Command(

--- a/main.go
+++ b/main.go
@@ -31,6 +31,11 @@ func main() {
 			EnvVar: "PLUGIN_NAME",
 		},
 		cli.StringSliceFlag{
+			Name:   "path",
+			Usage:  "paths for searching for coverage files",
+			EnvVar: "PLUGIN_PATHS",
+		},
+		cli.StringSliceFlag{
 			Name:   "file",
 			Usage:  "files for coverage upload",
 			EnvVar: "PLUGIN_FILES",
@@ -122,6 +127,7 @@ func run(c *cli.Context) error {
 			Token:    c.String("token"),
 			Name:     c.String("name"),
 			Pattern:  c.String("pattern"),
+			Paths:    c.StringSlice("path"),
 			Files:    c.StringSlice("file"),
 			Flags:    c.StringSlice("flag"),
 			Env:      c.StringSlice("env"),

--- a/plugin.go
+++ b/plugin.go
@@ -29,6 +29,7 @@ type (
 		Name     string
 		Pattern  string
 		Files    []string
+		Paths    []string
 		Flags    []string
 		Env      []string
 		Dump     bool

--- a/windows.go
+++ b/windows.go
@@ -59,6 +59,10 @@ func (p *Plugin) command() *exec.Cmd {
 		args = append(args, fmt.Sprintf("-f '%s'", file))
 	}
 
+	for _, path := range p.Config.Paths {
+		args = append(args, fmt.Sprintf("-s '%s'", path))
+	}
+
 	fmt.Println("$ codecov.exe", strings.Join(args, " "))
 
 	return exec.Command(


### PR DESCRIPTION
There is a limitation with codecoverage - that when using the `files` (`-f`) cli flag, it would not allow for paths with partial matches i.e.: 
```
files:
  - tests/output/coverage/*.xml 
```

Code coverage bash however allows for searching in specific paths - this PR adds the capability to do so

Ref: https://github.com/codecov/codecov-bash/blob/master/codecov#L103

the `-s` flag overrides the default directories from codecov (ref: https://github.com/codecov/codecov-bash/blob/master/codecov#L990 ).

With this PR - it would be possible to search for all xml files within a given path - example:
```
paths:
  - tests/output/coverage
files:
  - *.xml
```

